### PR TITLE
make cargo run platform agnostic

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.riscv32imac-unknown-none-elf]
-runner = "./flash.bat target/riscv32imac-unknown-none-elf/debug/esp32-mender-client"
+runner = "espflash flash --monitor -T ./partitions.csv --erase-parts otadata"
 
 [env]
 ESP_LOG="INFO"


### PR DESCRIPTION
I saw that the target was changed quite recently from @khiemspdt. .bat files are windows specific. I think it would be better to keep commands specific to `cargo` platform agnostic. What do you think?