### PR TITLE
use empty credentials on github actions

### DIFF
--- a/.github/workflows/clippy_fmt_check.yml
+++ b/.github/workflows/clippy_fmt_check.yml
@@ -1,6 +1,9 @@
 on: [push, pull_request]
 
 name: CI
+env:
+  MENDER_CLIENT_WIFI_SSID=""
+  MENDER_CLIENT_WIFI_PSK=""
 
 jobs:
   build:


### PR DESCRIPTION
The pipeline is failing because of unset credentials. For now lets use dummy values.